### PR TITLE
[Package] - Upgraded MediatR to Version 12.1.1

### DIFF
--- a/src/Core/Application/Application.csproj
+++ b/src/Core/Application/Application.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="Ardalis.Specification" Version="6.1.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
         <PackageReference Include="Mapster" Version="7.3.0" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Localization" Version="7.0.4" />
     </ItemGroup>

--- a/src/Core/Application/Startup.cs
+++ b/src/Core/Application/Startup.cs
@@ -10,6 +10,9 @@ public static class Startup
         var assembly = Assembly.GetExecutingAssembly();
         return services
             .AddValidatorsFromAssembly(assembly)
-            .AddMediatR(assembly);
+            .AddMediatR(mediatrServiceConfig =>
+            {
+                mediatrServiceConfig.RegisterServicesFromAssemblies(assembly);
+            });
     }
 }

--- a/src/Infrastructure/Startup.cs
+++ b/src/Infrastructure/Startup.cs
@@ -17,7 +17,6 @@ using FSH.WebApi.Infrastructure.Persistence;
 using FSH.WebApi.Infrastructure.Persistence.Initialization;
 using FSH.WebApi.Infrastructure.SecurityHeaders;
 using FSH.WebApi.Infrastructure.Validations;
-using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
@@ -45,7 +44,10 @@ public static class Startup
             .AddHealthCheck()
             .AddPOLocalization(config)
             .AddMailing(config)
-            .AddMediatR(Assembly.GetExecutingAssembly())
+            .AddMediatR(mediatrServiceConfig =>
+            {
+                mediatrServiceConfig.RegisterServicesFromAssemblies(Assembly.GetExecutingAssembly());
+            })
             .AddMultitenancy()
             .AddNotifications(config)
             .AddOpenApiDocumentation(config)


### PR DESCRIPTION
[Deprecated] - **MediatR.Extensions.Microsoft.DependencyInjection version 11.1.0** 

[Latest] - **MedaitR version 12.1.1**

[ISSUE-30] (https://github.com/fullstackhero/dotnet-webapi-boilerplate/issues/885)