### PR TITLE
Add response compression config

### DIFF
--- a/src/Infrastructure/Compression/Startup.cs
+++ b/src/Infrastructure/Compression/Startup.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.DependencyInjection;
+using System.IO.Compression;
+
+namespace FSH.WebApi.Infrastructure.Compression;
+
+internal static class Startup
+{
+    internal static IServiceCollection AddCompressions(this IServiceCollection services)
+    {
+        // Add Response compression services
+        services.AddResponseCompression(options =>
+         {
+             options.EnableForHttps = true;
+             options.Providers.Add<GzipCompressionProvider>();
+         });
+
+        services.Configure<GzipCompressionProviderOptions>(options =>
+        {
+            options.Level = CompressionLevel.Fastest;
+        });
+
+        return services;
+    }
+
+    internal static IApplicationBuilder UseCompressions(this IApplicationBuilder app) =>
+        app.UseResponseCompression();
+}

--- a/src/Infrastructure/Startup.cs
+++ b/src/Infrastructure/Startup.cs
@@ -1,9 +1,8 @@
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using FSH.WebApi.Infrastructure.Auth;
 using FSH.WebApi.Infrastructure.BackgroundJobs;
 using FSH.WebApi.Infrastructure.Caching;
 using FSH.WebApi.Infrastructure.Common;
+using FSH.WebApi.Infrastructure.Compression;
 using FSH.WebApi.Infrastructure.Cors;
 using FSH.WebApi.Infrastructure.FileStorage;
 using FSH.WebApi.Infrastructure.Localization;
@@ -23,6 +22,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Infrastructure.Test")]
 
@@ -52,6 +53,7 @@ public static class Startup
             .AddPersistence()
             .AddRequestLogging(config)
             .AddRouting(options => options.LowercaseUrls = true)
+            .AddCompressions()
             .AddServices();
     }
 
@@ -77,6 +79,7 @@ public static class Startup
 
     public static IApplicationBuilder UseInfrastructure(this IApplicationBuilder builder, IConfiguration config) =>
         builder
+            .UseCompressions()
             .UseRequestLocalization()
             .UseStaticFiles()
             .UseSecurityHeaders(config)


### PR DESCRIPTION
### Response compression in ASP.NET Core

> Network bandwidth is a limited resource. Reducing the size of the response usually increases the responsiveness of an app, often dramatically. One way to reduce payload sizes is to compress an app's responses.

Read more [Response compression in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/performance/response-compression?view=aspnetcore-7.0)