### PR TITLE
fix: specs builder nullable enum support

### DIFF
--- a/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
+++ b/src/Core/Application/Common/Specification/SpecificationBuilderExtensions.cs
@@ -251,6 +251,15 @@ public static class SpecificationBuilderExtensions
             return Expression.Constant(valueparsed, propertyType);
         }
 
+        if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Nullable<>) && propertyType.GetGenericArguments()[0].IsEnum)
+        {
+            string? stringEnum = GetStringFromJsonElement(value);
+
+            if (!Enum.TryParse(propertyType.GetGenericArguments()[0], stringEnum, true, out object? valueparsed)) throw new CustomException(string.Format("Value {0} is not valid for {1}", value, field));
+
+            return Expression.Constant(valueparsed, propertyType);
+        }
+
         if (propertyType == typeof(Guid))
         {
             string? stringGuid = GetStringFromJsonElement(value);


### PR DESCRIPTION
The condition above "if (propertyType.IsEnum)" is false, when enum is nullable. This will handle nullable enums